### PR TITLE
Create the Cache Folder If It Doesn't Exist

### DIFF
--- a/game-client/src/main/java/net/dodian/client/Signlink.java
+++ b/game-client/src/main/java/net/dodian/client/Signlink.java
@@ -110,10 +110,16 @@ public final class Signlink implements Runnable {
         Path cacheDirectory = Paths.get(CACHE_LOCAL_DIRECTORY);
         if (Files.exists(cacheDirectory) && Files.isDirectory(cacheDirectory)) {
             cacheDir = CACHE_LOCAL_DIRECTORY;
-            return cacheDir;
+        } else {
+            try {
+                Files.createDirectories(cacheDirectory);
+                cacheDir = CACHE_LOCAL_DIRECTORY;
+            } catch (IOException e) {
+                throw new RuntimeException("Failed to create cache directory: " + cacheDirectory.toAbsolutePath(), e);
+            }
         }
 
-        throw new RuntimeException("Failed to find or create cache directory at: " + cacheDirectory.toAbsolutePath());
+        return cacheDir;
     }
 
     private static int getuid(String s) {


### PR DESCRIPTION
- I noticed both on macOS 14 and Windows 11 that if you don't have the .dodian-osrs folder, the client will not download the cache and will be stuck on the Starting Up screen. I've also noticed that some people in discord have also been stuck.

- This PR will allow new users to play without manually creating the .dodian-osrs folder in the home directory

<img width="877" alt="Screenshot 2023-07-18 at 4 09 32 PM" src="https://github.com/dodian-community/ub3r-monorepo/assets/31579541/ac1ebd2a-7ee9-42d8-b91a-de8b36ba27e5">

<img width="1209" alt="Screenshot 2023-07-18 at 4 11 14 PM" src="https://github.com/dodian-community/ub3r-monorepo/assets/31579541/4a3af44b-07d2-47f0-946c-2850be93c3ab">